### PR TITLE
feat: added ui opt to customize the `width` and `height` for buffer and `size` for `toggleterm` ouput results

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,17 @@ Neovim 0.7+ is required
 
 ```
 {
+  ui = {
+    buffer = { -- width and height for the buffer output
+      width = 100,
+      height = 60
+    },
+    toggleterm = { -- by default no size is defined for the toggleterm by
+      -- greyjoy.nvim it will be dependent on the user configured size for toggle
+      -- term.
+      size = nil,
+    }
+  },
   enable = true,
   border = "rounded", -- style for vim.ui.selector
   style = "minimal",

--- a/lua/greyjoy/config.lua
+++ b/lua/greyjoy/config.lua
@@ -1,5 +1,16 @@
 -- Defaults
 local defaults = {
+    ui = {
+      buffer = { -- setting for buffer output
+        width = 100,
+        height = 60,
+      },
+      toggleterm = { -- by default no size is defined for the toggleterm by
+        -- greyjoy.nvim it will be dependent on the user configured size for toggle
+        -- term.
+        size = nil
+      },
+    },
     enable = true, -- enable/disable plugin
     border = "rounded", -- default borders
     style = "minimal", -- default style

--- a/lua/greyjoy/init.lua
+++ b/lua/greyjoy/init.lua
@@ -96,8 +96,11 @@ greyjoy.to_toggleterm = function(command)
     end
 
     local commandstr = table.concat(command.command, " ")
-    toggleterm.exec_command(
-        "dir='" .. command.path .. "' cmd='" .. commandstr .. "'")
+    local exec_command = "dir='" .. command.path .. "' cmd='" .. commandstr .. "'"
+    if greyjoy.ui.toggleterm.size then
+      exec_command = "size=" .. greyjoy.ui.toggleterm.size .. " " .. exec_command
+    end
+    toggleterm.exec_command(exec_command)
 end
 
 greyjoy.to_buffer = function(command)

--- a/lua/greyjoy/init.lua
+++ b/lua/greyjoy/init.lua
@@ -118,8 +118,8 @@ greyjoy.to_buffer = function(command)
         })
     end
 
-    local width = 100
-    local height = 50
+    local width = greyjoy.ui.buffer.width
+    local height = greyjoy.ui.buffer.height
 
     local ui = vim.api.nvim_list_uis()[1]
     local opts = {


### PR DESCRIPTION
Hello, @desdic i have been using your plugin and it has been a great addition to my workflow. It lacked one feature which was to give user option to customize the UI of the output results.

I have added those opts please merge this if you like it.